### PR TITLE
Allow `authn_field` GUC to be changed on SIGHUP

### DIFF
--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -33,7 +33,7 @@ static char* authn_field = nullptr;
 extern "C" void _PG_init() {
   DefineCustomStringVariable("pg_oidc_validator.authn_field",
                              gettext_noop("OAuth field used for matching PostgreSQL users"), nullptr, &authn_field,
-                             "sub", PGC_POSTMASTER, 0, nullptr, nullptr, nullptr);
+                             "sub", PGC_SIGHUP, 0, nullptr, nullptr, nullptr);
 }
 
 bool validate_token(const ValidatorModuleState* state, const char* token, const char* role,


### PR DESCRIPTION
Since the pg_hba.conf can be reloaded on SIGHUP it does make sense to allow the same for the `pg_oidc_validator.authn_field` GUC to be reloaded on SIGHUP.