### PR TITLE
PG-1962: Force linking libstdc++ (statically)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-SHLIB_LINK += -lcurl
+SHLIB_LINK += -lcurl -static-libstdc++
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(PG_CPPFLAGS) -c -o $@ $<


### PR DESCRIPTION
Issue: in the PGDG+PGXS setup postgres is linked with the `gcc` command, which means that our make command also links with `gcc` and not `g++`. This results in unresolved externals for the C++ symbols.

Solution: add libstdc++ to the linker flags. Since we also don't want to conflict with possible other C++ plugins, and we do not need C++ ABI compatiblity with other plugins/postgres, we link libstdc++ statically to avoid possible conflicts.

Fixes #9 