### PR TITLE
Also check the "scope" attribute in the access token

### DIFF
--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -197,7 +197,7 @@ scopes_t parse_jwt_scopes(const picojson::value& jsonScopes) {
     return {jsonScopes.get<std::string>()};
   }
 
-  throw std::runtime_error("JWT 'scp' claim is neither an array nor a string");
+  return {};
 }
 
 bool azure_scopes_match(const scopes_t& required_scopes, const scopes_t& received_scopes) {


### PR DESCRIPTION
The current code only checked the "scp" shorthad, but some providers actually return the longer "scope" variant. The updated code accepts both forms.