### PR TITLE
Parse multiple roles as string

### DIFF
--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -201,7 +201,9 @@ scopes_t parse_jwt_scopes(const picojson::value& jsonScopes) {
     return {scope_range.begin(), scope_range.end()};
   }
   if (jsonScopes.is<std::string>()) {
-    return {jsonScopes.get<std::string>()};
+    auto scope_range = jsonScopes.get<std::string>() | std::views::split(' ') |
+                       std::views::transform([](auto r) { return std::string(r.data(), r.size()); });
+    return {scope_range.begin(), scope_range.end()};
   }
 
   return {};


### PR DESCRIPTION
Even if the access token contains a string for the scopes or scp claims, and not an array, it might still contain multiple scopes separated by spaces.

This was not handled by the current code.

This commit splits strings like this into multiple scopes to handle the situation properly.