### PR TITLE
Fix PG 18 LTO build warnings: picojson _storage ODR violation

### DIFF
--- a/src/http_client.hpp
+++ b/src/http_client.hpp
@@ -1,5 +1,13 @@
 #pragma once
 
+// jwt-cpp defines PICOJSON_USE_INT64 before including picojson.h, adding
+// an int64_t member to picojson::_storage.  Without the same define here,
+// http_client.o sees a differently-shaped union than the other translation
+// units, triggering -Wodr and -Wlto-type-mismatch under LTO (-flto).
+// Keep in sync with what jwt-cpp/jwt.h does.
+#ifndef PICOJSON_USE_INT64
+#define PICOJSON_USE_INT64
+#endif
 #include <picojson/picojson.h>
 
 #include <optional>


### PR DESCRIPTION
jwt-cpp defines PICOJSON_USE_INT64 before including picojson.h, which
adds an int64_t member to picojson::_storage.  http_client.hpp lacked
the define, so http_client.o saw a different union layout than jwk.o
and pg_oidc_validator.o.  GCC LTO (-flto, active in the PG 18 RPM
build flags) reports this as -Wodr / -Wlto-type-mismatch on every
picojson::value use (get_json, clear, get<>, constructors).
Fix: add the same #ifndef / #define guard that jwt-cpp/jwt.h uses,
immediately before the picojson include.
