### PR TITLE
Fix build failures on GCC 11 / libstdc++ 11 (RHEL 9)

### DIFF
--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -1,7 +1,9 @@
 #include "jwk.hpp"
 
+#include <iterator>
 #include <ranges>
 #include <regex>
+#include <sstream>
 
 extern "C" {
 #include "postgres.h"
@@ -39,7 +41,7 @@ void configure_rsa_key(const picojson::object& keyObject, const std::string& kid
   const auto e_it = keyObject.find("e");
 
   if (n_it == keyObject.end() || e_it == keyObject.end()) {
-    throw std::runtime_error(std::format("RSA key missing required 'n'/'e' components (kid: {})", kid));
+    throw std::runtime_error("RSA key missing required 'n'/'e' components (kid: " + kid + ")");
   }
 
   const std::string n = n_it->second.to_str();
@@ -60,7 +62,7 @@ void configure_rsa_key(const picojson::object& keyObject, const std::string& kid
   } else if (alg == "PS512") {
     verifier = verifier.allow_algorithm(jwt::algorithm::ps512(pem_key));
   } else {
-    throw std::runtime_error(std::format("Unsupported RSA algorithm: {} (kid: {})", alg, kid));
+    throw std::runtime_error("Unsupported RSA algorithm: " + alg + " (kid: " + kid + ")");
   }
 }
 
@@ -71,7 +73,7 @@ void configure_ec_key(const picojson::object& keyObject, const std::string& kid,
   const auto crv_it = keyObject.find("crv");
 
   if (x_it == keyObject.end() || y_it == keyObject.end() || crv_it == keyObject.end()) {
-    throw std::runtime_error(std::format("EC key missing required 'x'/'y'/'crv' components (kid: {})", kid));
+    throw std::runtime_error("EC key missing required 'x'/'y'/'crv' components (kid: " + kid + ")");
   }
 
   const std::string x = x_it->second.to_str();
@@ -87,7 +89,7 @@ void configure_ec_key(const picojson::object& keyObject, const std::string& kid,
   } else if (alg == "ES512" && crv == "P-521") {
     verifier = verifier.allow_algorithm(jwt::algorithm::es512(pem_key));
   } else {
-    throw std::runtime_error(std::format("Unsupported EC algorithm/curve combination: {}/{} (kid: {})", alg, crv, kid));
+    throw std::runtime_error("Unsupported EC algorithm/curve combination: " + alg + "/" + crv + " (kid: " + kid + ")");
   }
 }
 
@@ -96,7 +98,7 @@ void configure_hmac_key(const picojson::object& keyObject, const std::string& ki
   const auto k_it = keyObject.find("k");
 
   if (k_it == keyObject.end()) {
-    throw std::runtime_error(std::format("HMAC key missing required 'k' component (kid: {})", kid));
+    throw std::runtime_error("HMAC key missing required 'k' component (kid: " + kid + ")");
   }
 
   const std::string k = keyObject.at("k").to_str();
@@ -108,13 +110,13 @@ void configure_hmac_key(const picojson::object& keyObject, const std::string& ki
   } else if (alg == "HS512") {
     verifier = verifier.allow_algorithm(jwt::algorithm::hs512{k});
   } else {
-    throw std::runtime_error(std::format("Unsupported HMAC algorithm: {} (kid: {})", alg, kid));
+    throw std::runtime_error("Unsupported HMAC algorithm: " + alg + " (kid: " + kid + ")");
   }
 }
 
 std::string get_required_parameter(picojson::object const& key_object, std::string const& name) {
   if (!key_object.contains(name)) {
-    throw std::runtime_error(std::format("Required parameter '{}' is missing", name));
+    throw std::runtime_error("Required parameter '" + name + "' is missing");
   }
   return key_object.at(name).to_str();
 }
@@ -171,7 +173,7 @@ jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const picoj
     } else if (kty == "oct") {
       configure_hmac_key(key_object, kid, alg, verifier);
     } else {
-      throw std::runtime_error(std::format("Unsupported key type: {} (kid: {})", kty, kid));
+      throw std::runtime_error("Unsupported key type: " + kty + " (kid: " + kid + ")");
     }
 
     break;
@@ -201,9 +203,8 @@ scopes_t parse_jwt_scopes(const picojson::value& jsonScopes) {
     return {scope_range.begin(), scope_range.end()};
   }
   if (jsonScopes.is<std::string>()) {
-    auto scope_range = jsonScopes.get<std::string>() | std::views::split(' ') |
-                       std::views::transform([](auto r) { return std::string(r.data(), r.size()); });
-    return {scope_range.begin(), scope_range.end()};
+    std::istringstream iss(jsonScopes.get<std::string>());
+    return scopes_t(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>{});
   }
 
   return {};

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -1,6 +1,8 @@
 #include <jwt-cpp/jwt.h>
 
+#include <iterator>
 #include <ranges>
+#include <sstream>
 #include <string>
 
 #include "http_cache.hpp"
@@ -48,10 +50,9 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
     elog(WARNING, "Failed to attach to HTTP cache: %s", ex.what());
   }
 
-  auto required_scopes_range = std::string(MyProcPort->hba->oauth_scope) | std::views::split(' ') |
-                               std::views::transform([](auto r) { return std::string(r.data(), r.size()); });
-
-  const scopes_t required_scopes(required_scopes_range.begin(), required_scopes_range.end());
+  std::istringstream required_iss(std::string(MyProcPort->hba->oauth_scope));
+  const scopes_t required_scopes(std::istream_iterator<std::string>(required_iss),
+                                 std::istream_iterator<std::string>{});
   const std::string issuer = MyProcPort->hba->oauth_issuer;
 
   http_client http;
@@ -94,8 +95,11 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   PG_TRY();
   {
     if (!payload.contains(authn_field)) {
-      const auto available_claims = payload | std::views::keys | std::views::join_with(std::string(", "));
-      const std::string claims_str(available_claims.begin(), available_claims.end());
+      std::string claims_str;
+      for (const auto& kv : payload) {
+        if (!claims_str.empty()) claims_str += ", ";
+        claims_str += kv.first;
+      }
       elog(WARNING, "OAuth failed: claim '%s' (authn_field) is missing. Available claims: %s", authn_field,
            claims_str.c_str());
       return false;
@@ -124,10 +128,16 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   }
 
   if (!res->authorized) {
-    const auto req = required_scopes | std::views::join_with(std::string(", "));
-    const std::string req_str(req.begin(), req.end());
-    const auto rec = received_scopes | std::views::join_with(std::string(", "));
-    const std::string rec_str(rec.begin(), rec.end());
+    std::string req_str;
+    for (const auto& s : required_scopes) {
+      if (!req_str.empty()) req_str += ", ";
+      req_str += s;
+    }
+    std::string rec_str;
+    for (const auto& s : received_scopes) {
+      if (!rec_str.empty()) rec_str += ", ";
+      rec_str += s;
+    }
     elog(LOG, "Authorization failed because of scope mismatch. Required scopes: %s. Received scopes: %s",
          req_str.c_str(), rec_str.c_str());
   } else {


### PR DESCRIPTION
Three families of C++20/23 features that GCC 11's libstdc++ does not implement cause hard compile errors even when -std=c++23 is passed. This patch replaces the previous (incomplete) attempt and addresses all of them starting from the original source files.

src/jwk.cpp + src/pg_oidc_validator.cpp  -  std::format (8 sites, jwk.cpp)
  std::format was standardised in C++20 but libstdc++ did not ship it
  until GCC 13.  Every call is replaced with equivalent std::string
  concatenation.

src/jwk.cpp + src/pg_oidc_validator.cpp  -  split_view | transform pipeline
  Two separate GCC 11 defects make this pattern permanently broken:
  (a) split_view's inner iterator and sentinel are DIFFERENT types
      (_InnerIter<false> vs. std::default_sentinel_t).  The two-argument
      std::string constructor requires identical iterator types, so
      std::string(r.begin(), r.end()) fails with "deduced conflicting
      types for parameter '_InputIterator'".
  (b) owning_view (P2415R2) was not part of GCC 11, so piping a
      temporary std::string into a range adaptor also fails.
  The entire split | transform pipeline is replaced with std::istringstream
  + std::istream_iterator<std::string>, which tokenises on whitespace, is well-specified since C++98, and compiles on all supported toolchains. Necessary headers <iterator> and <sstream> are added to both files.

src/pg_oidc_validator.cpp  -  std::views::join_with (3 sites)
  join_with (P2441R2) is C++23 and absent from libstdc++ 11.  All three
  uses are replaced with a simple accumulating for-loop.