### PR TITLE
PG-2526 Relax empty-scope handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ psql 'host=127.0.0.1 dbname=name user=rolename oauth_issuer=https://127.0.0.1:80
 Google has some quirks which are currently not supported by the libpq device code implementation.
 It is only usable with custom clients that do not rely on the internal device flow.
 
+## Dex
+Dex doesn't support OAuth scopes, it doesn't include the parameter in the tokens.
+While the use of scopes is strongly recommended for OAuth, and the parameter is required in pg_hba, it can be the empty string.
+Specifying `scope=""` disables scope validation.
+
 ## Testing
 
 The validator has a basic test suite, documented under [test/README.md](test/README.md).

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -96,7 +96,11 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const auto json_scope = parse_jwt_scopes(decoded_token.get_payload_json()["scope"]);
   received_scopes.insert(json_scope.begin(), json_scope.end());
 
-  if (received_scopes.empty()) {
+  if (required_scopes.empty()) {
+    // An explicitly empty scope opts out of scope validation.
+    // While this isn't recommended, it gives a workaround for some OIDC providers.
+    elog(DEBUG1, "Configured scope is empty; skipping scope validation");
+  } else if (received_scopes.empty()) {
     elog(WARNING, "Access token contains no scopes");
   }
 
@@ -123,7 +127,9 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   }
   PG_END_TRY();
 
-  if (issuer_is_azure(issuer)) {
+  if (required_scopes.empty()) {
+    res->authorized = true;
+  } else if (issuer_is_azure(issuer)) {
     if (strcmp(authn_field, "sub") == 0) {
       elog(WARNING,
            "sub field is not guaranteed to be unique with Entra ID, consider using a different field for user "


### PR DESCRIPTION
oauth_scope is a required paramter in pg_hba, but users can specify an empty string to it, allowing for an explicit opt-out for scope validation.

This is a workaround for providers that do not support OAuth scopes properly.